### PR TITLE
Update DOI, ORCID and Twitter links to use HTTPS

### DIFF
--- a/models/badge.py
+++ b/models/badge.py
@@ -434,7 +434,7 @@ class megafan(BadgeAssigner):
                     self.candidate_badge.add_product(my_product)  # add the one for the new max
                     biggest_fan = fan_name
 
-        self.candidate_badge.support = u"Thanks, <a href='http://twitter.com/{fan}'>@{fan}</a>.".format(
+        self.candidate_badge.support = u"Thanks, <a href='https://twitter.com/{fan}'>@{fan}</a>.".format(
             fan=biggest_fan)
 
 
@@ -676,7 +676,7 @@ class famous_follower(BadgeAssigner):
         if len(fans) > 1:
             self.assigned = True
             self.candidate_badge.value = len(fans)
-            fan_urls = [u"<a href='http://twitter.com/{fan}'>@{fan}</a>".format(fan=fan) for fan in fans]
+            fan_urls = [u"<a href='https://twitter.com/{fan}'>@{fan}</a>".format(fan=fan) for fan in fans]
             self.candidate_badge.support = u"The Big Deal Scientists who tweeted your research include: {}".format(u",".join(fan_urls))
 
 
@@ -807,7 +807,7 @@ class famous_follower(BadgeAssigner):
 #
 #         if self.assigned:
 #             self.candidate_badge.value = len(fans)
-#             fan_urls = [u"<a href='http://twitter.com/{fan}'>@{fan}</a>".format(fan=fan) for fan in fans]
+#             fan_urls = [u"<a href='https://twitter.com/{fan}'>@{fan}</a>".format(fan=fan) for fan in fans]
 #             self.candidate_badge.support = u"BFFs include: {}".format(u",".join(fan_urls))
 #
 

--- a/models/product.py
+++ b/models/product.py
@@ -190,7 +190,7 @@ class Product(db.Model):
         start_time = time()
 
         if self.doi:
-            self.url = u"http://doi.org/{}".format(self.doi)
+            self.url = u"https://doi.org/{}".format(self.doi)
 
         self.set_altmetric_score()
         self.set_altmetric_id()
@@ -467,7 +467,7 @@ class Product(db.Model):
     #
     #         if twitter_handle not in tweeter_dicts:
     #             tweeter_dict = {}
-    #             tweeter_dict["url"] = u"http://twitter.com/{}".format(twitter_handle)
+    #             tweeter_dict["url"] = u"https://twitter.com/{}".format(twitter_handle)
     #
     #             if "name" in post["author"]:
     #                 tweeter_dict["name"] = post["author"]["name"]

--- a/static/dist/templates.js
+++ b/static/dist/templates.js
@@ -124,7 +124,7 @@ angular.module("about-pages/about-data.tpl.html", []).run(["$templateCache", fun
     "            </li>\n" +
     "        </ol>\n" +
     "        <p>\n" +
-    "            Need any help? Contact us <a href=\"http://twitter.com/impactstory\">on Twitter</a> or open a help\n" +
+    "            Need any help? Contact us <a href=\"https://twitter.com/impactstory\">on Twitter</a> or open a help\n" +
     "            ticket by clicking the help icon at the bottom right of your screen.\n" +
     "        </p>\n" +
     "    </div>\n" +
@@ -151,7 +151,7 @@ angular.module("about-pages/about-data.tpl.html", []).run(["$templateCache", fun
     "            of our profile system.\n" +
     "        </li>\n" +
     "        <li>\n" +
-    "            <a href=\"http://twitter.com\">Twitter</a> supplies a convenient identity provider for signin (also, more Twitter\n" +
+    "            <a href=\"https://twitter.com\">Twitter</a> supplies a convenient identity provider for signin (also, more Twitter\n" +
     "            analytics are on the roadmap).\n" +
     "        </li>\n" +
     "    </ul>\n" +
@@ -281,7 +281,7 @@ angular.module("about-pages/about.tpl.html", []).run(["$templateCache", function
     "       </p>\n" +
     "       <p>\n" +
     "           Contact us via <a href=\"mailto:team@impactstory.org\">email</a> or\n" +
-    "           <a href=\"http://twitter.com/impactstory\">Twitter.</a>\n" +
+    "           <a href=\"https://twitter.com/impactstory\">Twitter.</a>\n" +
     "\n" +
     "       </p>\n" +
     "       <p>\n" +
@@ -296,7 +296,7 @@ angular.module("about-pages/about.tpl.html", []).run(["$templateCache", function
     "         <img src=\"/static/img/heather.jpg\" height=100/>\n" +
     "         <p><strong>Heather Piwowar</strong> is a cofounder of Impactstory and a leading researcher in research data availability and data reuse. She wrote one of the first papers measuring the <a href=\"http://www.plosone.org/article/info:doi/10.1371/journal.pone.0000308\">citation benefit of publicly available research data</a>, has studied  <a href=\"http://www.plosone.org/article/info:doi/10.1371/journal.pone.0018657\">patterns in  data archiving</a>, <a href=\"https://peerj.com/preprints/1/\">patterns of data reuse</a>, and the <a href=\"http://researchremix.wordpress.com/2010/10/12/journalpolicyproposal\">impact of journal data sharing policies</a>.</p>\n" +
     "\n" +
-    "         <p>Heather has a bachelor’s and master’s degree from MIT in electrical engineering, 10 years of experience as a software engineer, and a Ph.D. in Biomedical Informatics from the U of Pittsburgh.  She is an <a href=\"http://www.slideshare.net/hpiwowar\">frequent speaker</a> on research data archiving, writes a well-respected <a href=\"http://researchremix.wordpress.com\">research blog</a>, and is active on twitter (<a href=\"http://twitter.com/researchremix\">@researchremix</a>). </p>\n" +
+    "         <p>Heather has a bachelor’s and master’s degree from MIT in electrical engineering, 10 years of experience as a software engineer, and a Ph.D. in Biomedical Informatics from the U of Pittsburgh.  She is an <a href=\"http://www.slideshare.net/hpiwowar\">frequent speaker</a> on research data archiving, writes a well-respected <a href=\"http://researchremix.wordpress.com\">research blog</a>, and is active on twitter (<a href=\"https://twitter.com/researchremix\">@researchremix</a>). </p>\n" +
     "      </div>\n" +
     "\n" +
     "      <div class=\"team-member subsequent\">\n" +
@@ -356,7 +356,7 @@ angular.module("about-pages/about.tpl.html", []).run(["$templateCache", function
     "\n" +
     "      <div id=\"contact\">\n" +
     "         <h3>Contact</h3>\n" +
-    "         <p>We'd love to hear your feedback, ideas, or just chat! Reach us at <a href=\"mailto:team@impactstory.org\">team@impactstory.org</a> or on <a href=\"http://twitter.com/Impactstory\">twitter</a>.\n" +
+    "         <p>We'd love to hear your feedback, ideas, or just chat! Reach us at <a href=\"mailto:team@impactstory.org\">team@impactstory.org</a> or on <a href=\"https://twitter.com/Impactstory\">twitter</a>.\n" +
     "      </div>\n" +
     "\n" +
     "\n" +
@@ -373,7 +373,7 @@ angular.module("about-pages/sample.tpl.html", []).run(["$templateCache", functio
     "        <div class=\"product row\" ng-repeat=\"product in products\">\n" +
     "            <div class=\"id col-xs-2\">{{ product.id }}</div>\n" +
     "            <div class=\"link col-xs-10\">\n" +
-    "                <a href=\"http://doi.org/{{ product.doi }}\">{{ product.title }}</a>\n" +
+    "                <a href=\"https://doi.org/{{ product.doi }}\">{{ product.title }}</a>\n" +
     "\n" +
     "            </div>\n" +
     "\n" +
@@ -658,14 +658,14 @@ angular.module("group-page/group-page.tpl.html", []).run(["$templateCache", func
     "                                <a href=\"/u/{{ person.orcid_id }}\">{{ person.given_names }} {{ person.family_name }}</a>\n" +
     "\n" +
     "                                <span class=\"accounts\">\n" +
-    "                                    <a href=\"http://orcid.org/{{ person.orcid_id }}\">\n" +
+    "                                    <a href=\"https://orcid.org/{{ person.orcid_id }}\">\n" +
     "                                        <img src=\"static/img/favicons/orcid.ico\" alt=\"\">\n" +
     "                                    </a>\n" +
     "                                    <a href=\"http://depsy.org/person/{{ person.depsy_id }}\"\n" +
     "                                            ng-show=\"person.depsy_id\">\n" +
     "                                        <img src=\"static/img/favicons/depsy.png\" alt=\"\">\n" +
     "                                    </a>\n" +
-    "                                    <a href=\"http://twitter.com/{{ person.twitter }}\"\n" +
+    "                                    <a href=\"https://twitter.com/{{ person.twitter }}\"\n" +
     "                                       ng-show=\"person.twitter\"\n" +
     "                                       class=\"twitter\">\n" +
     "                                        <img src=\"static/img/favicons/twitter.ico\" alt=\"\">\n" +
@@ -747,14 +747,14 @@ angular.module("group-page/group-page.tpl.html", []).run(["$templateCache", func
     "                            <a href=\"/u/{{ person.orcid_id }}\">{{ person.given_names }} {{ person.family_name }}</a>\n" +
     "\n" +
     "                            <span class=\"accounts\">\n" +
-    "                                <a href=\"http://orcid.org/{{ person.orcid_id }}\">\n" +
+    "                                <a href=\"https://orcid.org/{{ person.orcid_id }}\">\n" +
     "                                    <img src=\"static/img/favicons/orcid.ico\" alt=\"\">\n" +
     "                                </a>\n" +
     "                                <a href=\"http://depsy.org/person/{{ person.depsy_id }}\"\n" +
     "                                        ng-show=\"person.depsy_id\">\n" +
     "                                    <img src=\"static/img/favicons/depsy.png\" alt=\"\">\n" +
     "                                </a>\n" +
-    "                                <a href=\"http://twitter.com/{{ person.twitter }}\"\n" +
+    "                                <a href=\"https://twitter.com/{{ person.twitter }}\"\n" +
     "                                   ng-show=\"person.twitter\"\n" +
     "                                   class=\"twitter\">\n" +
     "                                    <img src=\"static/img/favicons/twitter.ico\" alt=\"\">\n" +
@@ -861,7 +861,7 @@ angular.module("group-page/group-page.tpl.html", []).run(["$templateCache", func
     "                                    <a href=\"https://en.wikipedia.org/wiki/Happy_Fun_Ball\" class=\"fun\">super super fun.</a>\n" +
     "                                    Just, in ways our scholarly communication website cannot yet measure.\n" +
     "                                    Got an idea for a way we can fix that? Hit us up via\n" +
-    "                                    <a href=\"http://twitter.com/impactstory\">Twitter</a> or\n" +
+    "                                    <a href=\"https://twitter.com/impactstory\">Twitter</a> or\n" +
     "                                    <a href=\"mailto:team@impactstory.org\">email!</a>\n" +
     "                                </span>\n" +
     "                            </span>\n" +
@@ -1134,14 +1134,14 @@ angular.module("person-page/person-page.tpl.html", []).run(["$templateCache", fu
     "                       {{ person.d.given_names }} {{ person.d.family_name }}\n" +
     "\n" +
     "                        <span class=\"accounts\">\n" +
-    "                            <a href=\"http://orcid.org/{{ person.d.orcid_id }}\">\n" +
+    "                            <a href=\"https://orcid.org/{{ person.d.orcid_id }}\">\n" +
     "                                <img src=\"static/img/favicons/orcid.ico\" alt=\"\">\n" +
     "                            </a>\n" +
     "                            <a href=\"http://depsy.org/person/{{ person.d.depsy_id }}\"\n" +
     "                                    ng-show=\"person.d.depsy_id\">\n" +
     "                                <img src=\"static/img/favicons/depsy.png\" alt=\"\">\n" +
     "                            </a>\n" +
-    "                            <a href=\"http://twitter.com/{{ person.d.twitter }}\"\n" +
+    "                            <a href=\"https://twitter.com/{{ person.d.twitter }}\"\n" +
     "                               ng-show=\"person.d.twitter\"\n" +
     "                               class=\"twitter\">\n" +
     "                                <img src=\"static/img/favicons/twitter.ico\" alt=\"\">\n" +
@@ -1206,7 +1206,7 @@ angular.module("person-page/person-page.tpl.html", []).run(["$templateCache", fu
     "        </h2>\n" +
     "        <p>\n" +
     "            That's probably because {{ person.d.first_name }} hasn't associated any\n" +
-    "            works with <a href=\"http://orcid.org/{{ person.d.orcid_id }}\">his or her ORCID profile.</a>\n" +
+    "            works with <a href=\"https://orcid.org/{{ person.d.orcid_id }}\">his or her ORCID profile.</a>\n" +
     "        </p>\n" +
     "    </div>\n" +
     "\n" +
@@ -1443,7 +1443,7 @@ angular.module("person-page/person-page.tpl.html", []).run(["$templateCache", fu
     "                                    <a href=\"https://en.wikipedia.org/wiki/Happy_Fun_Ball\" class=\"fun\">super super fun.</a>\n" +
     "                                    Just, in ways our scholarly communication website cannot yet measure.\n" +
     "                                    Got an idea for a way we can fix that? Hit us up via\n" +
-    "                                    <a href=\"http://twitter.com/impactstory\">Twitter</a> or\n" +
+    "                                    <a href=\"https://twitter.com/impactstory\">Twitter</a> or\n" +
     "                                    <a href=\"mailto:team@impactstory.org\">email!</a>\n" +
     "                                </span>\n" +
     "                            </span>\n" +
@@ -1764,7 +1764,7 @@ angular.module("product-page/product-page.tpl.html", []).run(["$templateCache", 
     "\n" +
     "            <div class=\"journal\">\n" +
     "                <span class=\"year\">{{product.year}}</span>\n" +
-    "                <a href=\"http://doi.org/{{ product.doi }}\"\n" +
+    "                <a href=\"https://doi.org/{{ product.doi }}\"\n" +
     "                   ng-show=\"product.doi\"\n" +
     "                   class=\"journal\">\n" +
     "                    {{product.journal}}\n" +
@@ -1817,7 +1817,7 @@ angular.module("product-page/product-page.tpl.html", []).run(["$templateCache", 
     "                <p>\n" +
     "                    If you've\n" +
     "                    got a DOI for this publication we don't know about, you can add\n" +
-    "                    it in <a href=\"http://orcid.org/{{ person.d.orcid_id }}\" target=\"_blank\">your ORCID</a>\n" +
+    "                    it in <a href=\"https://orcid.org/{{ person.d.orcid_id }}\" target=\"_blank\">your ORCID</a>\n" +
     "                    and then re-sync.\n" +
     "                </p>\n" +
     "            </div>\n" +
@@ -2180,7 +2180,7 @@ angular.module("static-pages/landing.tpl.html", []).run(["$templateCache", funct
     "    <div class=\"landing-footer\">\n" +
     "        <div class=\"links col\">\n" +
     "            <a href=\"about\">About</a>\n" +
-    "            <a href=\"http://twitter.com/impactstory\">Twitter</a>\n" +
+    "            <a href=\"https://twitter.com/impactstory\">Twitter</a>\n" +
     "            <a href=\"https://github.com/Impactstory/impactstory-tng\">GitHub</a>\n" +
     "        </div>\n" +
     "        <div class=\"funders col\">\n" +
@@ -2348,7 +2348,7 @@ angular.module("wizard/connect-orcid.tpl.html", []).run(["$templateCache", funct
     "            <p>Let's get your profile set up.</p>\n" +
     "\n" +
     "            <p>\n" +
-    "                Impactstory is built on <a href=\"http://orcid.org\">ORCID</a>,\n" +
+    "                Impactstory is built on <a href=\"https://orcid.org\">ORCID</a>,\n" +
     "                a global nonprofit registry of researchers and their publications.\n" +
     "            </p>\n" +
     "            <p>Do you have an ORCID ID?</p>\n" +

--- a/static/dist/ti.js
+++ b/static/dist/ti.js
@@ -2734,7 +2734,7 @@ angular.module("about-pages/about-data.tpl.html", []).run(["$templateCache", fun
     "            </li>\n" +
     "        </ol>\n" +
     "        <p>\n" +
-    "            Need any help? Contact us <a href=\"http://twitter.com/impactstory\">on Twitter</a> or open a help\n" +
+    "            Need any help? Contact us <a href=\"https://twitter.com/impactstory\">on Twitter</a> or open a help\n" +
     "            ticket by clicking the help icon at the bottom right of your screen.\n" +
     "        </p>\n" +
     "    </div>\n" +
@@ -2761,7 +2761,7 @@ angular.module("about-pages/about-data.tpl.html", []).run(["$templateCache", fun
     "            of our profile system.\n" +
     "        </li>\n" +
     "        <li>\n" +
-    "            <a href=\"http://twitter.com\">Twitter</a> supplies a convenient identity provider for signin (also, more Twitter\n" +
+    "            <a href=\"https://twitter.com\">Twitter</a> supplies a convenient identity provider for signin (also, more Twitter\n" +
     "            analytics are on the roadmap).\n" +
     "        </li>\n" +
     "    </ul>\n" +
@@ -2891,7 +2891,7 @@ angular.module("about-pages/about.tpl.html", []).run(["$templateCache", function
     "       </p>\n" +
     "       <p>\n" +
     "           Contact us via <a href=\"mailto:team@impactstory.org\">email</a> or\n" +
-    "           <a href=\"http://twitter.com/impactstory\">Twitter.</a>\n" +
+    "           <a href=\"https://twitter.com/impactstory\">Twitter.</a>\n" +
     "\n" +
     "       </p>\n" +
     "       <p>\n" +
@@ -2906,7 +2906,7 @@ angular.module("about-pages/about.tpl.html", []).run(["$templateCache", function
     "         <img src=\"/static/img/heather.jpg\" height=100/>\n" +
     "         <p><strong>Heather Piwowar</strong> is a cofounder of Impactstory and a leading researcher in research data availability and data reuse. She wrote one of the first papers measuring the <a href=\"http://www.plosone.org/article/info:doi/10.1371/journal.pone.0000308\">citation benefit of publicly available research data</a>, has studied  <a href=\"http://www.plosone.org/article/info:doi/10.1371/journal.pone.0018657\">patterns in  data archiving</a>, <a href=\"https://peerj.com/preprints/1/\">patterns of data reuse</a>, and the <a href=\"http://researchremix.wordpress.com/2010/10/12/journalpolicyproposal\">impact of journal data sharing policies</a>.</p>\n" +
     "\n" +
-    "         <p>Heather has a bachelor’s and master’s degree from MIT in electrical engineering, 10 years of experience as a software engineer, and a Ph.D. in Biomedical Informatics from the U of Pittsburgh.  She is an <a href=\"http://www.slideshare.net/hpiwowar\">frequent speaker</a> on research data archiving, writes a well-respected <a href=\"http://researchremix.wordpress.com\">research blog</a>, and is active on twitter (<a href=\"http://twitter.com/researchremix\">@researchremix</a>). </p>\n" +
+    "         <p>Heather has a bachelor’s and master’s degree from MIT in electrical engineering, 10 years of experience as a software engineer, and a Ph.D. in Biomedical Informatics from the U of Pittsburgh.  She is an <a href=\"http://www.slideshare.net/hpiwowar\">frequent speaker</a> on research data archiving, writes a well-respected <a href=\"http://researchremix.wordpress.com\">research blog</a>, and is active on twitter (<a href=\"https://twitter.com/researchremix\">@researchremix</a>). </p>\n" +
     "      </div>\n" +
     "\n" +
     "      <div class=\"team-member subsequent\">\n" +
@@ -2966,7 +2966,7 @@ angular.module("about-pages/about.tpl.html", []).run(["$templateCache", function
     "\n" +
     "      <div id=\"contact\">\n" +
     "         <h3>Contact</h3>\n" +
-    "         <p>We'd love to hear your feedback, ideas, or just chat! Reach us at <a href=\"mailto:team@impactstory.org\">team@impactstory.org</a> or on <a href=\"http://twitter.com/Impactstory\">twitter</a>.\n" +
+    "         <p>We'd love to hear your feedback, ideas, or just chat! Reach us at <a href=\"mailto:team@impactstory.org\">team@impactstory.org</a> or on <a href=\"https://twitter.com/Impactstory\">twitter</a>.\n" +
     "      </div>\n" +
     "\n" +
     "\n" +
@@ -2983,7 +2983,7 @@ angular.module("about-pages/sample.tpl.html", []).run(["$templateCache", functio
     "        <div class=\"product row\" ng-repeat=\"product in products\">\n" +
     "            <div class=\"id col-xs-2\">{{ product.id }}</div>\n" +
     "            <div class=\"link col-xs-10\">\n" +
-    "                <a href=\"http://doi.org/{{ product.doi }}\">{{ product.title }}</a>\n" +
+    "                <a href=\"https://doi.org/{{ product.doi }}\">{{ product.title }}</a>\n" +
     "\n" +
     "            </div>\n" +
     "\n" +
@@ -3268,14 +3268,14 @@ angular.module("group-page/group-page.tpl.html", []).run(["$templateCache", func
     "                                <a href=\"/u/{{ person.orcid_id }}\">{{ person.given_names }} {{ person.family_name }}</a>\n" +
     "\n" +
     "                                <span class=\"accounts\">\n" +
-    "                                    <a href=\"http://orcid.org/{{ person.orcid_id }}\">\n" +
+    "                                    <a href=\"https://orcid.org/{{ person.orcid_id }}\">\n" +
     "                                        <img src=\"static/img/favicons/orcid.ico\" alt=\"\">\n" +
     "                                    </a>\n" +
     "                                    <a href=\"http://depsy.org/person/{{ person.depsy_id }}\"\n" +
     "                                            ng-show=\"person.depsy_id\">\n" +
     "                                        <img src=\"static/img/favicons/depsy.png\" alt=\"\">\n" +
     "                                    </a>\n" +
-    "                                    <a href=\"http://twitter.com/{{ person.twitter }}\"\n" +
+    "                                    <a href=\"https://twitter.com/{{ person.twitter }}\"\n" +
     "                                       ng-show=\"person.twitter\"\n" +
     "                                       class=\"twitter\">\n" +
     "                                        <img src=\"static/img/favicons/twitter.ico\" alt=\"\">\n" +
@@ -3357,14 +3357,14 @@ angular.module("group-page/group-page.tpl.html", []).run(["$templateCache", func
     "                            <a href=\"/u/{{ person.orcid_id }}\">{{ person.given_names }} {{ person.family_name }}</a>\n" +
     "\n" +
     "                            <span class=\"accounts\">\n" +
-    "                                <a href=\"http://orcid.org/{{ person.orcid_id }}\">\n" +
+    "                                <a href=\"https://orcid.org/{{ person.orcid_id }}\">\n" +
     "                                    <img src=\"static/img/favicons/orcid.ico\" alt=\"\">\n" +
     "                                </a>\n" +
     "                                <a href=\"http://depsy.org/person/{{ person.depsy_id }}\"\n" +
     "                                        ng-show=\"person.depsy_id\">\n" +
     "                                    <img src=\"static/img/favicons/depsy.png\" alt=\"\">\n" +
     "                                </a>\n" +
-    "                                <a href=\"http://twitter.com/{{ person.twitter }}\"\n" +
+    "                                <a href=\"https://twitter.com/{{ person.twitter }}\"\n" +
     "                                   ng-show=\"person.twitter\"\n" +
     "                                   class=\"twitter\">\n" +
     "                                    <img src=\"static/img/favicons/twitter.ico\" alt=\"\">\n" +
@@ -3471,7 +3471,7 @@ angular.module("group-page/group-page.tpl.html", []).run(["$templateCache", func
     "                                    <a href=\"https://en.wikipedia.org/wiki/Happy_Fun_Ball\" class=\"fun\">super super fun.</a>\n" +
     "                                    Just, in ways our scholarly communication website cannot yet measure.\n" +
     "                                    Got an idea for a way we can fix that? Hit us up via\n" +
-    "                                    <a href=\"http://twitter.com/impactstory\">Twitter</a> or\n" +
+    "                                    <a href=\"https://twitter.com/impactstory\">Twitter</a> or\n" +
     "                                    <a href=\"mailto:team@impactstory.org\">email!</a>\n" +
     "                                </span>\n" +
     "                            </span>\n" +
@@ -3744,14 +3744,14 @@ angular.module("person-page/person-page.tpl.html", []).run(["$templateCache", fu
     "                       {{ person.d.given_names }} {{ person.d.family_name }}\n" +
     "\n" +
     "                        <span class=\"accounts\">\n" +
-    "                            <a href=\"http://orcid.org/{{ person.d.orcid_id }}\">\n" +
+    "                            <a href=\"https://orcid.org/{{ person.d.orcid_id }}\">\n" +
     "                                <img src=\"static/img/favicons/orcid.ico\" alt=\"\">\n" +
     "                            </a>\n" +
     "                            <a href=\"http://depsy.org/person/{{ person.d.depsy_id }}\"\n" +
     "                                    ng-show=\"person.d.depsy_id\">\n" +
     "                                <img src=\"static/img/favicons/depsy.png\" alt=\"\">\n" +
     "                            </a>\n" +
-    "                            <a href=\"http://twitter.com/{{ person.d.twitter }}\"\n" +
+    "                            <a href=\"https://twitter.com/{{ person.d.twitter }}\"\n" +
     "                               ng-show=\"person.d.twitter\"\n" +
     "                               class=\"twitter\">\n" +
     "                                <img src=\"static/img/favicons/twitter.ico\" alt=\"\">\n" +
@@ -3816,7 +3816,7 @@ angular.module("person-page/person-page.tpl.html", []).run(["$templateCache", fu
     "        </h2>\n" +
     "        <p>\n" +
     "            That's probably because {{ person.d.first_name }} hasn't associated any\n" +
-    "            works with <a href=\"http://orcid.org/{{ person.d.orcid_id }}\">his or her ORCID profile.</a>\n" +
+    "            works with <a href=\"https://orcid.org/{{ person.d.orcid_id }}\">his or her ORCID profile.</a>\n" +
     "        </p>\n" +
     "    </div>\n" +
     "\n" +
@@ -4053,7 +4053,7 @@ angular.module("person-page/person-page.tpl.html", []).run(["$templateCache", fu
     "                                    <a href=\"https://en.wikipedia.org/wiki/Happy_Fun_Ball\" class=\"fun\">super super fun.</a>\n" +
     "                                    Just, in ways our scholarly communication website cannot yet measure.\n" +
     "                                    Got an idea for a way we can fix that? Hit us up via\n" +
-    "                                    <a href=\"http://twitter.com/impactstory\">Twitter</a> or\n" +
+    "                                    <a href=\"https://twitter.com/impactstory\">Twitter</a> or\n" +
     "                                    <a href=\"mailto:team@impactstory.org\">email!</a>\n" +
     "                                </span>\n" +
     "                            </span>\n" +
@@ -4374,7 +4374,7 @@ angular.module("product-page/product-page.tpl.html", []).run(["$templateCache", 
     "\n" +
     "            <div class=\"journal\">\n" +
     "                <span class=\"year\">{{product.year}}</span>\n" +
-    "                <a href=\"http://doi.org/{{ product.doi }}\"\n" +
+    "                <a href=\"https://doi.org/{{ product.doi }}\"\n" +
     "                   ng-show=\"product.doi\"\n" +
     "                   class=\"journal\">\n" +
     "                    {{product.journal}}\n" +
@@ -4427,7 +4427,7 @@ angular.module("product-page/product-page.tpl.html", []).run(["$templateCache", 
     "                <p>\n" +
     "                    If you've\n" +
     "                    got a DOI for this publication we don't know about, you can add\n" +
-    "                    it in <a href=\"http://orcid.org/{{ person.d.orcid_id }}\" target=\"_blank\">your ORCID</a>\n" +
+    "                    it in <a href=\"https://orcid.org/{{ person.d.orcid_id }}\" target=\"_blank\">your ORCID</a>\n" +
     "                    and then re-sync.\n" +
     "                </p>\n" +
     "            </div>\n" +
@@ -4790,7 +4790,7 @@ angular.module("static-pages/landing.tpl.html", []).run(["$templateCache", funct
     "    <div class=\"landing-footer\">\n" +
     "        <div class=\"links col\">\n" +
     "            <a href=\"about\">About</a>\n" +
-    "            <a href=\"http://twitter.com/impactstory\">Twitter</a>\n" +
+    "            <a href=\"https://twitter.com/impactstory\">Twitter</a>\n" +
     "            <a href=\"https://github.com/Impactstory/impactstory-tng\">GitHub</a>\n" +
     "        </div>\n" +
     "        <div class=\"funders col\">\n" +
@@ -4958,7 +4958,7 @@ angular.module("wizard/connect-orcid.tpl.html", []).run(["$templateCache", funct
     "            <p>Let's get your profile set up.</p>\n" +
     "\n" +
     "            <p>\n" +
-    "                Impactstory is built on <a href=\"http://orcid.org\">ORCID</a>,\n" +
+    "                Impactstory is built on <a href=\"https://orcid.org\">ORCID</a>,\n" +
     "                a global nonprofit registry of researchers and their publications.\n" +
     "            </p>\n" +
     "            <p>Do you have an ORCID ID?</p>\n" +

--- a/static/src/about-pages/about-data.tpl.html
+++ b/static/src/about-pages/about-data.tpl.html
@@ -32,7 +32,7 @@
             </li>
         </ol>
         <p>
-            Need any help? Contact us <a href="http://twitter.com/impactstory">on Twitter</a> or open a help
+            Need any help? Contact us <a href="https://twitter.com/impactstory">on Twitter</a> or open a help
             ticket by clicking the help icon at the bottom right of your screen.
         </p>
     </div>
@@ -59,7 +59,7 @@
             of our profile system.
         </li>
         <li>
-            <a href="http://twitter.com">Twitter</a> supplies a convenient identity provider for signin (also, more Twitter
+            <a href="https://twitter.com">Twitter</a> supplies a convenient identity provider for signin (also, more Twitter
             analytics are on the roadmap).
         </li>
     </ul>

--- a/static/src/about-pages/about.tpl.html
+++ b/static/src/about-pages/about.tpl.html
@@ -20,7 +20,7 @@
        </p>
        <p>
            Contact us via <a href="mailto:team@impactstory.org">email</a> or
-           <a href="http://twitter.com/impactstory">Twitter.</a>
+           <a href="https://twitter.com/impactstory">Twitter.</a>
 
        </p>
        <p>
@@ -35,7 +35,7 @@
          <img src="/static/img/heather.jpg" height=100/>
          <p><strong>Heather Piwowar</strong> is a cofounder of Impactstory and a leading researcher in research data availability and data reuse. She wrote one of the first papers measuring the <a href="http://www.plosone.org/article/info:doi/10.1371/journal.pone.0000308">citation benefit of publicly available research data</a>, has studied  <a href="http://www.plosone.org/article/info:doi/10.1371/journal.pone.0018657">patterns in  data archiving</a>, <a href="https://peerj.com/preprints/1/">patterns of data reuse</a>, and the <a href="http://researchremix.wordpress.com/2010/10/12/journalpolicyproposal">impact of journal data sharing policies</a>.</p>
 
-         <p>Heather has a bachelor’s and master’s degree from MIT in electrical engineering, 10 years of experience as a software engineer, and a Ph.D. in Biomedical Informatics from the U of Pittsburgh.  She is an <a href="http://www.slideshare.net/hpiwowar">frequent speaker</a> on research data archiving, writes a well-respected <a href="http://researchremix.wordpress.com">research blog</a>, and is active on twitter (<a href="http://twitter.com/researchremix">@researchremix</a>). </p>
+         <p>Heather has a bachelor’s and master’s degree from MIT in electrical engineering, 10 years of experience as a software engineer, and a Ph.D. in Biomedical Informatics from the U of Pittsburgh.  She is an <a href="http://www.slideshare.net/hpiwowar">frequent speaker</a> on research data archiving, writes a well-respected <a href="http://researchremix.wordpress.com">research blog</a>, and is active on twitter (<a href="https://twitter.com/researchremix">@researchremix</a>). </p>
       </div>
 
       <div class="team-member subsequent">
@@ -95,7 +95,7 @@
 
       <div id="contact">
          <h3>Contact</h3>
-         <p>We'd love to hear your feedback, ideas, or just chat! Reach us at <a href="mailto:team@impactstory.org">team@impactstory.org</a> or on <a href="http://twitter.com/Impactstory">twitter</a>.
+         <p>We'd love to hear your feedback, ideas, or just chat! Reach us at <a href="mailto:team@impactstory.org">team@impactstory.org</a> or on <a href="https://twitter.com/Impactstory">twitter</a>.
       </div>
 
 

--- a/static/src/about-pages/sample.tpl.html
+++ b/static/src/about-pages/sample.tpl.html
@@ -5,7 +5,7 @@
         <div class="product row" ng-repeat="product in products">
             <div class="id col-xs-2">{{ product.id }}</div>
             <div class="link col-xs-10">
-                <a href="http://doi.org/{{ product.doi }}">{{ product.title }}</a>
+                <a href="https://doi.org/{{ product.doi }}">{{ product.title }}</a>
 
             </div>
 

--- a/static/src/group-page/group-page.tpl.html
+++ b/static/src/group-page/group-page.tpl.html
@@ -64,14 +64,14 @@
                                 <a href="/u/{{ person.orcid_id }}">{{ person.given_names }} {{ person.family_name }}</a>
 
                                 <span class="accounts">
-                                    <a href="http://orcid.org/{{ person.orcid_id }}">
+                                    <a href="https://orcid.org/{{ person.orcid_id }}">
                                         <img src="static/img/favicons/orcid.ico" alt="">
                                     </a>
                                     <a href="http://depsy.org/person/{{ person.depsy_id }}"
                                             ng-show="person.depsy_id">
                                         <img src="static/img/favicons/depsy.png" alt="">
                                     </a>
-                                    <a href="http://twitter.com/{{ person.twitter }}"
+                                    <a href="https://twitter.com/{{ person.twitter }}"
                                        ng-show="person.twitter"
                                        class="twitter">
                                         <img src="static/img/favicons/twitter.ico" alt="">
@@ -153,14 +153,14 @@
                             <a href="/u/{{ person.orcid_id }}">{{ person.given_names }} {{ person.family_name }}</a>
 
                             <span class="accounts">
-                                <a href="http://orcid.org/{{ person.orcid_id }}">
+                                <a href="https://orcid.org/{{ person.orcid_id }}">
                                     <img src="static/img/favicons/orcid.ico" alt="">
                                 </a>
                                 <a href="http://depsy.org/person/{{ person.depsy_id }}"
                                         ng-show="person.depsy_id">
                                     <img src="static/img/favicons/depsy.png" alt="">
                                 </a>
-                                <a href="http://twitter.com/{{ person.twitter }}"
+                                <a href="https://twitter.com/{{ person.twitter }}"
                                    ng-show="person.twitter"
                                    class="twitter">
                                     <img src="static/img/favicons/twitter.ico" alt="">
@@ -267,7 +267,7 @@
                                     <a href="https://en.wikipedia.org/wiki/Happy_Fun_Ball" class="fun">super super fun.</a>
                                     Just, in ways our scholarly communication website cannot yet measure.
                                     Got an idea for a way we can fix that? Hit us up via
-                                    <a href="http://twitter.com/impactstory">Twitter</a> or
+                                    <a href="https://twitter.com/impactstory">Twitter</a> or
                                     <a href="mailto:team@impactstory.org">email!</a>
                                 </span>
                             </span>

--- a/static/src/person-page/person-page.tpl.html
+++ b/static/src/person-page/person-page.tpl.html
@@ -23,14 +23,14 @@
                        {{ person.d.given_names }} {{ person.d.family_name }}
 
                         <span class="accounts">
-                            <a href="http://orcid.org/{{ person.d.orcid_id }}">
+                            <a href="https://orcid.org/{{ person.d.orcid_id }}">
                                 <img src="static/img/favicons/orcid.ico" alt="">
                             </a>
                             <a href="http://depsy.org/person/{{ person.d.depsy_id }}"
                                     ng-show="person.d.depsy_id">
                                 <img src="static/img/favicons/depsy.png" alt="">
                             </a>
-                            <a href="http://twitter.com/{{ person.d.twitter }}"
+                            <a href="https://twitter.com/{{ person.d.twitter }}"
                                ng-show="person.d.twitter"
                                class="twitter">
                                 <img src="static/img/favicons/twitter.ico" alt="">
@@ -95,7 +95,7 @@
         </h2>
         <p>
             That's probably because {{ person.d.first_name }} hasn't associated any
-            works with <a href="http://orcid.org/{{ person.d.orcid_id }}">his or her ORCID profile.</a>
+            works with <a href="https://orcid.org/{{ person.d.orcid_id }}">his or her ORCID profile.</a>
         </p>
     </div>
 
@@ -332,7 +332,7 @@
                                     <a href="https://en.wikipedia.org/wiki/Happy_Fun_Ball" class="fun">super super fun.</a>
                                     Just, in ways our scholarly communication website cannot yet measure.
                                     Got an idea for a way we can fix that? Hit us up via
-                                    <a href="http://twitter.com/impactstory">Twitter</a> or
+                                    <a href="https://twitter.com/impactstory">Twitter</a> or
                                     <a href="mailto:team@impactstory.org">email!</a>
                                 </span>
                             </span>

--- a/static/src/product-page/product-page.tpl.html
+++ b/static/src/product-page/product-page.tpl.html
@@ -18,7 +18,7 @@
 
             <div class="journal">
                 <span class="year">{{product.year}}</span>
-                <a href="http://doi.org/{{ product.doi }}"
+                <a href="https://doi.org/{{ product.doi }}"
                    ng-show="product.doi"
                    class="journal">
                     {{product.journal}}
@@ -71,7 +71,7 @@
                 <p>
                     If you've
                     got a DOI for this publication we don't know about, you can add
-                    it in <a href="http://orcid.org/{{ person.d.orcid_id }}" target="_blank">your ORCID</a>
+                    it in <a href="https://orcid.org/{{ person.d.orcid_id }}" target="_blank">your ORCID</a>
                     and then re-sync.
                 </p>
             </div>

--- a/static/src/static-pages/landing.tpl.html
+++ b/static/src/static-pages/landing.tpl.html
@@ -42,7 +42,7 @@
     <div class="landing-footer">
         <div class="links col">
             <a href="about">About</a>
-            <a href="http://twitter.com/impactstory">Twitter</a>
+            <a href="https://twitter.com/impactstory">Twitter</a>
             <a href="https://github.com/Impactstory/impactstory-tng">GitHub</a>
         </div>
         <div class="funders col">

--- a/static/src/wizard/connect-orcid.tpl.html
+++ b/static/src/wizard/connect-orcid.tpl.html
@@ -8,7 +8,7 @@
             <p>Let's get your profile set up.</p>
 
             <p>
-                Impactstory is built on <a href="http://orcid.org">ORCID</a>,
+                Impactstory is built on <a href="https://orcid.org">ORCID</a>,
                 a global nonprofit registry of researchers and their publications.
             </p>
             <p>Do you have an ORCID ID?</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,7 +59,7 @@
       <div id="site-footer" class="row logged-in-{{ auth.isAuthenticated() }}">
          <div class="col-md-5 links">
             <a href="about">About</a>
-            <a href="http://twitter.com/impactstory">Twitter</a>
+            <a href="https://twitter.com/impactstory">Twitter</a>
             <a href="https://github.com/Impactstory/impactstory-tng">GitHub</a>
 
          </div>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -53,7 +53,7 @@
             Looking forward to hearing what you think! </a>
 
        <p>Best, Jason (<a href="https://impactstory.org/u/0000-0001-6187-6610">https://impactstory.org/u/0000-0001-6187-6610</a>) and Heather (<a href="https://impactstory.org/u/0000-0003-1613-5981">https://impactstory.org/u/0000-0003-1613-5981</a>)
-           <br><a href="http://twitter.com/impactstory">@impactstory</a></br>
+           <br><a href="https://twitter.com/impactstory">@impactstory</a></br>
            <br>team@impactstory.org</br>
         </p>
 


### PR DESCRIPTION
DOI, ORCID and Twitter all support HTTPS by default, but it helps users' security when they can follow links to the secure websites directly instead of having to be redirected.